### PR TITLE
Add timed greeting message overlay

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,7 @@
   <body>
     <body class="not-loaded">
       <div class="night"></div>
+      <div class="message" aria-live="polite">Have a beautiful day!</div>
       <div class="flowers">
         <div class="flower flower--1">
           <div class="flower__leafs flower__leafs--1">

--- a/docs/script.js
+++ b/docs/script.js
@@ -3,4 +3,15 @@ onload = () => {
     document.body.classList.remove('not-loaded')
     clearTimeout(c)
   }, 1000)
+
+  const message = document.querySelector('.message')
+  if (message) {
+    setTimeout(() => {
+      message.classList.add('message--visible')
+    }, 4000)
+
+    setTimeout(() => {
+      message.classList.remove('message--visible')
+    }, 9000)
+  }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -20,6 +20,32 @@ body {
   perspective: 1000px;
 }
 
+.message {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 1rem 2rem;
+  color: #fff7c2;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  letter-spacing: 0.05em;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 1.5rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.5s ease;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.message.message--visible {
+  opacity: 1;
+  visibility: visible;
+}
+
 .night {
   position: fixed;
   left: 50%;


### PR DESCRIPTION
## Summary
- add a centered message overlay that appears briefly after the animation begins
- style the overlay to sit above the scene and fade in/out smoothly
- schedule the message to show after four seconds and hide again after nine seconds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cebdb16e588328bff05696f6c2622f